### PR TITLE
DoS in POC

### DIFF
--- a/CVE-2015-7547-poc.py
+++ b/CVE-2015-7547-poc.py
@@ -60,6 +60,9 @@ def udp_thread():
   while not terminate:
     data, addr = sock_udp.recvfrom(1024)
     print '[UDP] Total Data len recv ' + str(len(data))
+    if len(data) < 4:
+        print "[!!!] Invalid request, continuing"
+        continue
     id_udp = struct.unpack('>H', data[0:2])[0]
     query_udp = data[12:]
 
@@ -112,6 +115,9 @@ def tcp_thread():
 
     reqlen1 = socket.ntohs(struct.unpack('H', data[0:2])[0])
     print '[TCP] Request1 len recv ' + str(reqlen1)
+    if len(data) < 4:
+        print "[!!!] Invalid request, continuing"
+        continue
     data1 = data[2:2+reqlen1]
     id1 = struct.unpack('>H', data1[0:2])[0]
     query1 = data[12:]


### PR DESCRIPTION
My CVE-2015-7547 POC POC

The cause of this crash is a due to an unbounds check in processed data, assuming that at least four bytes of data are sent in the DNS request.  This causes a DoS condition in the POC, potentially stopping users from using the POC in hostile environments.

```
sh-4.2$ sudo python CVE-2015-7547-poc.py &
[1] 32066
sh-4.2$ nc -v localhost 53
Connected with 127.0.0.1:37640
Connection to localhost 53 port [tcp/domain] succeeded!
j
[TCP] Total Data len recv 2
[TCP] Request1 len recv 27146
Traceback (most recent call last):
  File "CVE-2015-7547-poc.py", line 176, in <module>
    tcp_thread()
  File "CVE-2015-7547-poc.py", line 116, in tcp_thread
    id1 = struct.unpack('>H', data1[0:2])[0]
struct.error: unpack requires a string argument of length 2
[1]+  Done(1)                 sudo python CVE-2015-7547-poc.py
```
