### PR TITLE
Add Python client to POC

### DIFF
--- a/CVE-2015-7547-client.py
+++ b/CVE-2015-7547-client.py
@@ -1,0 +1,4 @@
+#!/usr/bin/env python
+
+import socket
+socket.getaddrinfo("foo.bar.google.com", "80")


### PR DESCRIPTION
Bypass the build-client-with-gcc step for the POC client.

$ ./CVE-2015-7547-client.py
Segmentation fault
