### PR TITLE
Add local client example to not require DNS setup to test

### DIFF
--- a/CVE-2015-7547-local-client.c
+++ b/CVE-2015-7547-local-client.c
@@ -1,0 +1,42 @@
+#include <stdio.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netdb.h>
+#include <netinet/in.h>
+#include <arpa/nameser.h>
+#include <resolv.h>
+#include <stdlib.h>
+#include <arpa/inet.h>
+#include <string.h>
+ 
+ 
+int main(void) {
+    struct in_addr server;
+    struct addrinfo hint, *result=0, *p=0;
+    struct sockaddr_in serverSock, *h=0;
+
+    //For our 'fake' resolution
+    struct addrinfo hints, *servinfo;
+
+    if(inet_pton(AF_INET, "127.0.0.1", &server) == 0) {
+        exit(1);
+    }
+    //Have to run getaddrinfo before we do this, atleast once, for some reason.
+    memset(&hints, 0, sizeof hints);
+    getaddrinfo("google.com", NULL, &hints, &servinfo);
+    freeaddrinfo((struct addrinfo*)servinfo);
+
+    serverSock.sin_family = AF_INET;
+    serverSock.sin_port = htons(53);
+    serverSock.sin_addr = server;
+
+    _res.nscount = 1;
+    _res.nsaddr_list[0] = serverSock;
+
+    memset(&hint, 0, sizeof hint);
+
+    int error;
+    if((error = getaddrinfo("foo.bar.google.com", NULL, &hint, (struct addrinfo**)&result)) != 0) {
+        errx(1, "getaddrinfo: %s", gai_strerror(error));
+    }
+}


### PR DESCRIPTION
This extra example client works locally without having to setup DNS NS records or changing the system resolver configuration. Code to do this was pulled from here: http://blog.internot.info/2015/03/specifying-dnsns-server-for-address.html
